### PR TITLE
removed the publishing of a battery_status message

### DIFF
--- a/src/lib/battery/battery.cpp
+++ b/src/lib/battery/battery.cpp
@@ -179,7 +179,8 @@ void Battery::publishBatteryStatus(const battery_status_s &battery_status)
 void Battery::updateAndPublishBatteryStatus(const hrt_abstime &timestamp)
 {
 	updateBatteryStatus(timestamp);
-	publishBatteryStatus(getBatteryStatus());
+	// publishBatteryStatus(getBatteryStatus());
+	// comment to remove empty battery_status message TEDOB
 }
 
 void Battery::sumDischarged(const hrt_abstime &timestamp, float current_a)


### PR DESCRIPTION
<!--

Thank you for your contribution!

Get early feedback through
- Dronecode Discord: https://discord.gg/dronecode
- PX4 Discuss: http://discuss.px4.io/
- opening a draft pr and sharing the link

-->

### Solved Problem
We had an empty `battery_status` message that meant the populated battery_status message was not being passed over the dds bridge

### Solution
removed the publish `battery_status` function in the primary battery moudule. so now only get published by the `batt_smbus` driver

### Alternatives
We could also add something on the dds side to specify the message instance

### Test coverage
- Sitl
- Hardware

